### PR TITLE
SI-2155-in-progress-event

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/lovoo/goka v1.1.9
 	github.com/prometheus/client_golang v1.12.1
 	github.com/rs/zerolog v1.28.0
+	github.com/segmentio/ksuid v1.0.4
 	github.com/smallstep/assert v0.0.0-20200723003110-82e2b9b3b262
 	github.com/stretchr/testify v1.8.4
 )

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/savsgio/dictpool v0.0.0-20221023140959-7bf2e61cea94/go.mod h1:90zrgN3
 github.com/savsgio/gotils v0.0.0-20220530130905-52f3993e8d6d/go.mod h1:Gy+0tqhJvgGlqnTF8CVGP0AaGRjwBtXs/a5PA0Y3+A4=
 github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee h1:8Iv5m6xEo1NR1AvpV+7XmhI4r39LGNzwUL4YpMuL5vk=
 github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee/go.mod h1:qwtSXrKuJh/zsFQ12yEE89xfCrGKK63Rr7ctU/uCo4g=
+github.com/segmentio/ksuid v1.0.4 h1:sBo2BdShXjmcugAMwjugoGUdUV0pcxY5mW4xKRn3v4c=
+github.com/segmentio/ksuid v1.0.4/go.mod h1:/XUiZBD3kVx5SmUOl55voK5yeAbBNNIed+2O73XgrPE=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=

--- a/services/segmenter/segmenter_test.go
+++ b/services/segmenter/segmenter_test.go
@@ -143,7 +143,8 @@ func TestSegmentProcessor_Process_StoreActiveSeg_LatLon(t *testing.T) {
 
 	v := gkt.TableValue("group-table", key)
 	value := v.(*State)
-	require.Equal(t, tblResult.ActiveSegment, value.ActiveSegment)
+	require.Equal(t, tblResult.ActiveSegment.Start, value.ActiveSegment.Start)
+	require.Equal(t, tblResult.ActiveSegment.LastMovement, value.ActiveSegment.LastMovement)
 }
 
 func TestSegmentProcessor_Process_StoreFirstObs_Speed(t *testing.T) {
@@ -277,7 +278,8 @@ func TestSegmentProcessor_Process_StoreActiveSeg_Speed(t *testing.T) {
 
 	v := gkt.TableValue("group-table", key)
 	value := v.(*State)
-	require.Equal(t, tblResult.ActiveSegment, value.ActiveSegment)
+	require.Equal(t, tblResult.ActiveSegment.LastMovement, value.ActiveSegment.LastMovement)
+	require.Equal(t, tblResult.ActiveSegment.Start, value.ActiveSegment.Start)
 }
 
 func float64Ptr(f float64) *float64 {


### PR DESCRIPTION
[ticket](https://linear.app/dimo/issue/SI-2155/display-in-progress-trips-in-the-api)

- Add fields to Segment Event: ID (unique string), Completed (bool)
- Emit segment event when a trip begins
- When we have determined that a segment has concluded, emit segment event where completed = true

### Notes
- a unique trip id is being stored/ emitted here so we can reference the trip in trips-api